### PR TITLE
Adds links to wemake templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If this setup is not what you are looking for, you might want look at other simi
 
 * [ariera/django-vue-template](https://github.com/ariera/django-vue-template)
 * [vchaptsev/cookiecutter-django-vue](https://github.com/vchaptsev/cookiecutter-django-vue)
+* [wemake-django-template](https://github.com/wemake-services/wemake-django-template) + [wemake-vue-template](https://github.com/wemake-services/wemake-vue-template)
 
 Prefer Flask? Checkout my [gtalarico/flask-vuejs-template](https://github.com/gtalarico/flask-vuejs-template)
 


### PR DESCRIPTION
We use these two with great success for our Vue and Django projects.

There are two cases: 
- They can be used together
- They can be used 100% separately 

But, the philosophy under these projects is shifted towards the micro-service use-case with two independent containers.
I guess, that it is a nice thing to have as an alternative.

Links:
- https://github.com/wemake-services/wemake-django-template
- https://github.com/wemake-services/wemake-vue-template