### PR TITLE
Fix dev server proxy to admin/rest_framework static assets

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -12,7 +12,7 @@ module.exports = {
     // and distribute
     devServer: {
       proxy: {
-        '/api*': {
+        '^/(api)|(static/admin)|(static/rest_framework)': {
           // Forward frontend dev server request for /api to django dev server
           target: 'http://localhost:8000/',
         }


### PR DESCRIPTION
Visiting http://localhost:8080/api/admin will not load the django admin css. You'll get 404 errors on /static/admin/*. Same with the rest_framework styling when you visit an api endpoint through the browser.

This PR fixes the issue by telling the dev server to proxy requests to /static/admin and /static/rest_framework to django.