### PR TITLE
add link to vue docs for public/index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Prefer Flask? Checkout my [gtalarico/flask-vuejs-template](https://github.com/gt
 | `/backend/api`       | Django App (`/api`)                        |
 | `/src`               | Vue App .                                  |
 | `/src/main.js`       | JS Application Entry Point                 |
-| `/public/index.html` | Html Application Entry Point (`/`)         |
+| `/public/index.html` | [Html Application Entry Point](https://cli.vuejs.org/guide/html-and-static-assets.html) (`/`)         |
 | `/public/static`     | Static Assets                              |
 | `/dist/`             | Bundled Assets Output (generated at `yarn build`) |
 


### PR DESCRIPTION
Related to: https://github.com/gtalarico/django-vue-template/pull/53

Thanks @gtalarico for taking the time to explain. Sorry about that, I'm obviously pretty new to this vue stuff.

Mind if I add this link to the vue docs about public/index.html to the readme?